### PR TITLE
enable receiver on UART

### DIFF
--- a/src/device/libpixy/uart.cpp
+++ b/src/device/libpixy/uart.cpp
@@ -77,7 +77,22 @@ int Uart::close()
 
 int Uart::receive(uint8_t *buf, uint32_t len)
 {
-	return 0;
+	uint32_t i;
+	uint8_t buf8;
+
+	for (i=0; i<len; i++)
+	{
+		if (m_rq.read(&buf8)==0)
+			break;
+		buf[i] = buf8;
+	}
+
+	return i;
+}
+
+int Uart::receiveLen()
+{	
+	return m_rq.receiveLen();
 }
 
 int Uart::update()

--- a/src/device/libpixy/uart.h
+++ b/src/device/libpixy/uart.h
@@ -31,6 +31,7 @@ public:
 	virtual int open();
 	virtual int close();
 	virtual int receive(uint8_t *buf, uint32_t len);
+	virtual int receiveLen();
 	virtual int update();
 
 	int setBaudrate(uint32_t baudrate);


### PR DESCRIPTION
This enables the UART receiver functions. The servos can be programmed
via UART like over SPI.
