### PR TITLE
made buildable in systems where file system is case sensitive

### DIFF
--- a/src/device/common/inc/platform_config.h
+++ b/src/device/common/inc/platform_config.h
@@ -186,7 +186,7 @@
 /* assign the roles for the devices */
 #if (DEVICE==LPC43xx)
 
-#include "LPC43xx.h"
+#include "lpc43xx.h"
 
 #define MASTER_CPU CORE_M4
 #define SLAVE_CPU CORE_M0

--- a/src/device/common/src/system_LPC43xx.c
+++ b/src/device/common/src/system_LPC43xx.c
@@ -38,7 +38,7 @@
 * use without further testing or modification.
 **********************************************************************/
 
-#include "LPC43xx.h"
+#include "lpc43xx.h"
 #include "lpc43xx_cgu.h"
 
 

--- a/src/device/libpixy_m4/src/platform_config.c
+++ b/src/device/libpixy_m4/src/platform_config.c
@@ -13,7 +13,7 @@
 // end license header
 //
 
-#include "LPC43xx.h"
+#include "lpc43xx.h"
 #include "platform_config.h"
 
 #include "lpc43xx_scu.h"

--- a/src/device/libpixy_m4/src/usbcore.c
+++ b/src/device/libpixy_m4/src/usbcore.c
@@ -36,7 +36,7 @@
  *                Reworked Endpoint0
  *          V1.00 Initial Version
  *----------------------------------------------------------------------------*/
-#include "lpc43xx.H"
+#include "lpc43xx.h"
 #include "lpc_types.h"
 
 #include "usb.h"

--- a/src/device/libpixy_m4/src/usbdesc.c
+++ b/src/device/libpixy_m4/src/usbdesc.c
@@ -34,7 +34,7 @@
  *          V1.20 Changed string descriptor handling
  *          V1.00 Initial Version
  *----------------------------------------------------------------------------*/
-#include "lpc43xx.H"
+#include "lpc43xx.h"
 #include "lpc_types.h"
 
 #include "usb.h"

--- a/src/device/libpixy_m4/src/usbhw.c
+++ b/src/device/libpixy_m4/src/usbhw.c
@@ -44,7 +44,7 @@
 * this code.
 **********************************************************************/
 #include <string.h>
-#include "lpc43xx.H"                        /* lpc43xx definitions */
+#include "lpc43xx.h"                        /* lpc43xx definitions */
 #include "lpc_types.h"
 #include "usb.h"
 #include "usbhw.h"

--- a/src/device/main_m4/src/analogdig.cpp
+++ b/src/device/main_m4/src/analogdig.cpp
@@ -13,7 +13,7 @@
 // end license header
 //
 
-#include "LPC43xx.h"
+#include "lpc43xx.h"
 #include "lpc43xx_scu.h"
 #include "misc.h"
 #include "cameravals.h"


### PR DESCRIPTION
I successfully built the gcc branch under Debian Wheezy, but needed to make these small changes because linux uses case sensitive file systems.