### PR TITLE
add support for multiple pixies to libpixyusb

### DIFF
--- a/src/host/hello_pixy/hello_pixy.cpp
+++ b/src/host/hello_pixy/hello_pixy.cpp
@@ -40,6 +40,7 @@ int main(int argc, char * argv[])
   int      index;
   int      blocks_copied;
   int      pixy_init_status;
+  uint32_t pixy_uid = 0;
   char     buf[128];
 
   // Catch CTRL+C (SIGINT) signals //
@@ -48,7 +49,9 @@ int main(int argc, char * argv[])
   printf("Hello Pixy:\n libpixyusb Version: %s\n", __LIBPIXY_VERSION__);
 
   // Connect to Pixy //
-  pixy_init_status = pixy_init();
+  if (argc == 2)
+    pixy_uid = strtoul(argv[1], NULL, 0);
+  pixy_init_status = pixy_init(pixy_uid);
 
   // Was there an error initializing pixy? //
   if(!pixy_init_status == 0)

--- a/src/host/libpixyusb/include/pixy.h
+++ b/src/host/libpixyusb/include/pixy.h
@@ -79,14 +79,16 @@ extern "C"
   };
 
   /**
-    @brief Creates a connection with Pixy and listens for Pixy messages.
+    @brief     Creates a connection with Pixy and listens for Pixy messages.
+    @param[in] uid  Connect to pixy with a specific uid, or pass zero to grab
+                    the first available.
     @return  0                         Success
     @return  PIXY_ERROR_USB_IO         USB Error: I/O
     @return  PIXY_ERROR_NOT_FOUND      USB Error: Pixy not found
     @return  PIXY_ERROR_USB_BUSY       USB Error: Busy
     @return  PIXY_ERROR_USB_NO_DEVICE  USB Error: No device
   */
-  int pixy_init();
+  int pixy_init(uint32_t uid);
 
   /**
     @brief      Indicates when new block data from Pixy is received.

--- a/src/host/libpixyusb/src/pixy.cpp
+++ b/src/host/libpixyusb/src/pixy.cpp
@@ -84,11 +84,11 @@ extern "C"
 
   static int pixy_initialized = false;
 
-  int pixy_init()
+  int pixy_init(uint32_t uid)
   {
     int return_value;
 
-    return_value = interpreter.init();
+    return_value = interpreter.init(uid);
 
     if(return_value == 0) 
     {

--- a/src/host/libpixyusb/src/pixyinterpreter.hpp
+++ b/src/host/libpixyusb/src/pixyinterpreter.hpp
@@ -35,18 +35,18 @@ class PixyInterpreter : public Interpreter
     ~PixyInterpreter();
 
     /**
-      @brief  Spawns an 'interpreter' thread which attempts to 
-              connect to Pixy using the USB interface. 
-              On successful connection, this thread will 
-              capture and store Pixy 'block' object data 
-              which can be retreived using the getBlocks()
-              method.
+      @brief      Spawns an 'interpreter' thread which attempts to connect to Pixy
+                  using the USB interface.  On successful connection, this
+                  thread will capture and store Pixy 'block' object data which
+                  can be retreived using the getBlocks() method.
+       @param[in] uid Connect to pixy with a specific uid, or pass zero to grab
+                      the first available.
        @return   0    Success
        @return  -1    Error: Unable to open pixy USB device
 
     */
   
-    int init();
+    int init(uint32_t uid=0);
     
     /**
       @brief  Terminates the USB connection to Pixy and

--- a/src/host/libpixyusb/src/usblink.h
+++ b/src/host/libpixyusb/src/usblink.h
@@ -26,16 +26,16 @@ public:
     USBLink();
     ~USBLink();
 
-    int open();
+    // Grab a handle for the first non-busy pixy device
+    int open(int ord=0);
     virtual int send(const uint8_t *data, uint32_t len, uint16_t timeoutMs);
     virtual int receive(uint8_t *data, uint32_t len, uint16_t timeoutMs);
     virtual void setTimer();
     virtual uint32_t getTimer();
 
 private:
-    libusb_context *m_context;
     libusb_device_handle *m_handle;
-
+    libusb_context *m_context;
     util::timer timer_;
 };
 


### PR DESCRIPTION
This issue was discussed on the wiki [here](http://cmucam.org/boards/9/topics/7431?r=7815#message-7815). 

I have only done basic testing using the hello_pixy example on my linux box. I tried running two instances in parallel and that works fine. I also tried opening a third one and open() indeed returns a `ERROR_BUSY` as expected. We should really run some more tests (especially on other platforms) but I haven't looked at what kind of testing infrastructure pixy has atm.

Note that I tried to be careful on handling error conditions. I return the error code unmolested wherever I could and only set the error code manually if no matching pixy device was found. This is different than the pixymon openDevice() implementation which plays it pretty fast and loose :p.

Also, I did a whitespace-cleanup in case you're wondering why some whitespace was removed.

**Edit**
Force pushed an update that makes sure that if libusb_open returns a non-busy error code that the loop exits immediately and the code is returned.