### PR TITLE
Avx 129 ir lock camera settings

### DIFF
--- a/src/device/common/inc/cameravals.h
+++ b/src/device/common/inc/cameravals.h
@@ -23,9 +23,11 @@
 #define CAM_LIGHT_LOW           1
 #define CAM_LIGHT_HIGH          2 // not sure if combining high light and low light exposure is possible, or good
 
-#define CAM_BRIGHTNESS_DEFAULT  80
+#define CAM_BRIGHTNESS_DEFAULT  90
 #define CAM_BRIGHTNESS_RANGE    0x14
 
+#define CAM_WBV_DEFAULT         8421504
+#define CAM_ECV_DEFAULT         8600
 
 #define CAM_RES0                0x00 
 #define CAM_RES1                0x01

--- a/src/device/libpixy_m4/src/camera.cpp
+++ b/src/device/libpixy_m4/src/camera.cpp
@@ -601,22 +601,22 @@ void cam_loadParams()
 	prm_setShadowCallback("Camera Brightness", (ShadowCallback)cam_shadowCallback);
 
 	prm_add("Auto Exposure Correction", PRM_FLAG_ADVANCED | PRM_FLAG_CHECKBOX, 
-		"@c Camera Enables/disables Auto Exposure Correction. (default enabled)", UINT8(1), END);
+		"@c Camera Enables/disables Auto Exposure Correction. (default disabled)", UINT8(0), END);
 	prm_setShadowCallback("Auto Exposure Correction", (ShadowCallback)cam_shadowCallback);
 
 	prm_add("AEC Value", PRM_FLAG_INTERNAL, 
-		"", UINT32(0), END);
+		"", UINT32(CAM_ECV_DEFAULT), END);
 																		   
 	prm_add("Auto White Balance", PRM_FLAG_ADVANCED | PRM_FLAG_CHECKBOX, 
 		"@c Camera Enables/disables Auto White Balance. When this is set, AWB is enabled continuously. (default disabled)", UINT8(0), END);
 	prm_setShadowCallback("Auto White Balance", (ShadowCallback)cam_shadowCallback);
 
 	prm_add("Auto White Balance on power-up", PRM_FLAG_ADVANCED | PRM_FLAG_CHECKBOX, 
-		"@c Camera Enables/disables Auto White Balance on power-up. When this is set, AWB is enabled only upon power-up. (default enabled)", UINT8(1), END);
+		"@c Camera Enables/disables Auto White Balance on power-up. When this is set, AWB is enabled only upon power-up. (default disabled)", UINT8(0), END);
 	prm_setShadowCallback("Auto White Balance on power-up", (ShadowCallback)cam_shadowCallback);
 
 	prm_add("AWB Value", PRM_FLAG_INTERNAL,
-		"", UINT32(0), END);
+		"", UINT32(CAM_WBV_DEFAULT), END);
 
 	uint8_t brightness, aec, awb, awbp;
 	uint32_t ecv, wbv;

--- a/src/device/main_m0/Release/main_m0_Release.ld
+++ b/src/device/main_m0/Release/main_m0_Release.ld
@@ -46,14 +46,6 @@ SECTIONS
         __bss_section_table = .;
         LONG(    ADDR(.bss));
         LONG(  SIZEOF(.bss));
-        LONG(    ADDR(.bss_RAM2));
-        LONG(  SIZEOF(.bss_RAM2));
-        LONG(    ADDR(.bss_RAM3));
-        LONG(  SIZEOF(.bss_RAM3));
-        LONG(    ADDR(.bss_RAM4));
-        LONG(  SIZEOF(.bss_RAM4));
-        LONG(    ADDR(.bss_RAM5));
-        LONG(  SIZEOF(.bss_RAM5));
         __bss_section_table_end = .;
         __section_table_end = . ;
         /* End of Global Section Table */
@@ -164,43 +156,6 @@ SECTIONS
 	   . = ALIGN(4) ;
 	   _edata = . ;
 	} > RamAHB16 AT>RamAHB16
-
-    /* BSS section for RamAHB32 */
-    .bss_RAM2 : ALIGN(4)
-    {
-       PROVIDE(__start_bss_RAM2 = .) ;
-    	*(.bss.$RAM2*)
-    	*(.bss.$RamAHB32*)
-       . = ALIGN(4) ;
-       PROVIDE(__end_bss_RAM2 = .) ;
-    } > RamAHB32
-    /* BSS section for RamLoc128 */
-    .bss_RAM3 : ALIGN(4)
-    {
-       PROVIDE(__start_bss_RAM3 = .) ;
-    	*(.bss.$RAM3*)
-    	*(.bss.$RamLoc128*)
-       . = ALIGN(4) ;
-       PROVIDE(__end_bss_RAM3 = .) ;
-    } > RamLoc128
-    /* BSS section for RamLoc72 */
-    .bss_RAM4 : ALIGN(4)
-    {
-       PROVIDE(__start_bss_RAM4 = .) ;
-    	*(.bss.$RAM4*)
-    	*(.bss.$RamLoc72*)
-       . = ALIGN(4) ;
-       PROVIDE(__end_bss_RAM4 = .) ;
-    } > RamLoc72
-    /* BSS section for RamAHB_ETB16 */
-    .bss_RAM5 : ALIGN(4)
-    {
-       PROVIDE(__start_bss_RAM5 = .) ;
-    	*(.bss.$RAM5*)
-    	*(.bss.$RamAHB_ETB16*)
-       . = ALIGN(4) ;
-       PROVIDE(__end_bss_RAM5 = .) ;
-    } > RamAHB_ETB16
 
     /* MAIN BSS SECTION */
     .bss : ALIGN(4)

--- a/src/device/main_m4/inc/exec.h
+++ b/src/device/main_m4/inc/exec.h
@@ -23,7 +23,7 @@
 
 #define FW_MAJOR_VER		2
 #define FW_MINOR_VER		0
-#define FW_BUILD_VER		19
+#define FW_BUILD_VER		20
 #ifdef LEGO
 #define FW_TYPE             "LEGO"
 #else

--- a/src/device/main_m4/linkscripts/SPIFI_link_template.ld
+++ b/src/device/main_m4/linkscripts/SPIFI_link_template.ld
@@ -68,14 +68,6 @@ SECTIONS
         __bss_section_table = .;
         LONG(    ADDR(.bss));
         LONG(  SIZEOF(.bss));
-        LONG(    ADDR(.bss_RAM2));
-        LONG(  SIZEOF(.bss_RAM2));
-        LONG(    ADDR(.bss_RAM3));
-        LONG(  SIZEOF(.bss_RAM3));
-        LONG(    ADDR(.bss_RAM4));
-        LONG(  SIZEOF(.bss_RAM4));
-        LONG(    ADDR(.bss_RAM5));
-        LONG(  SIZEOF(.bss_RAM5));
         __bss_section_table_end = .;
         __section_table_end = . ;
         /* End of Global Section Table */
@@ -230,35 +222,6 @@ SECTIONS
 	   . = ALIGN(4) ;
 	   _edata = . ;
 	} > RamLoc128 AT>SPIflash
-
-    /* BSS section for RamAHB32 */
-    .bss_RAM2 : ALIGN(4)
-    {
-    	*(.bss.$RAM2*)
-    	*(.bss.$RamAHB32*)
-       . = ALIGN(4) ;
-    } > RamAHB32
-    /* BSS section for RamLoc72 */
-    .bss_RAM3 : ALIGN(4)
-    {
-    	*(.bss.$RAM3*)
-    	*(.bss.$RamLoc72*)
-       . = ALIGN(4) ;
-    } > RamLoc72
-    /* BSS section for RamAHB16 */
-    .bss_RAM4 : ALIGN(4)
-    {
-    	*(.bss.$RAM4*)
-    	*(.bss.$RamAHB16*)
-       . = ALIGN(4) ;
-    } > RamAHB16
-    /* BSS section for RamAHB_ETB16 */
-    .bss_RAM5 : ALIGN(4)
-    {
-    	*(.bss.$RAM5*)
-    	*(.bss.$RamAHB_ETB16*)
-       . = ALIGN(4) ;
-    } > RamAHB_ETB16
 
     /* MAIN BSS SECTION */
     .bss : ALIGN(4)


### PR DESCRIPTION
Hard code IR-Lock camera settings so pixy camera doesn't need to be configured for use with IR-Lock.